### PR TITLE
Run webdriver-manager and protractor using relative paths

### DIFF
--- a/gulp-angular-protractor/web-driver.js
+++ b/gulp-angular-protractor/web-driver.js
@@ -74,7 +74,7 @@ module.exports = {
      * @returns {Object}
      */
     'runProtractor': function (args) {
-        return childProcess.spawn(PROTRACTOR_COMMAND, args, {
+        return childProcess.spawn(path.resolve(PROTRACTOR_DIR, PROTRACTOR_COMMAND), args, {
             'stdio': 'inherit',
             'env': process.env,
             'cwd': PROTRACTOR_DIR
@@ -113,7 +113,7 @@ module.exports = {
         var
             callbackWasCalled = false,
             logOutput = true,
-            command = childProcess.spawn(WEB_DRIVER_COMMAND, [WEB_DRIVER_START_COMMAND], { 'cwd': PROTRACTOR_DIR });
+            command = childProcess.spawn(path.resolve(PROTRACTOR_DIR, WEB_DRIVER_COMMAND), [WEB_DRIVER_START_COMMAND], { 'cwd': PROTRACTOR_DIR });
 
         command.once('close', function (errorCode) {
             gutil.log(PLUGIN_NAME + ' - Webdriver standalone server will be closed');

--- a/gulp-angular-protractor/web-driver.js
+++ b/gulp-angular-protractor/web-driver.js
@@ -74,7 +74,7 @@ module.exports = {
      * @returns {Object}
      */
     'runProtractor': function (args) {
-        return childProcess.spawn(path.resolve(PROTRACTOR_DIR, PROTRACTOR_COMMAND), args, {
+        return childProcess.spawn('./' + PROTRACTOR_COMMAND, args, {
             'stdio': 'inherit',
             'env': process.env,
             'cwd': PROTRACTOR_DIR
@@ -113,7 +113,7 @@ module.exports = {
         var
             callbackWasCalled = false,
             logOutput = true,
-            command = childProcess.spawn(path.resolve(PROTRACTOR_DIR, WEB_DRIVER_COMMAND), [WEB_DRIVER_START_COMMAND], { 'cwd': PROTRACTOR_DIR });
+            command = childProcess.spawn('./' + WEB_DRIVER_COMMAND, [WEB_DRIVER_START_COMMAND], { 'cwd': PROTRACTOR_DIR });
 
         command.once('close', function (errorCode) {
             gutil.log(PLUGIN_NAME + ' - Webdriver standalone server will be closed');


### PR DESCRIPTION
Fixes #12.

Apparently the plugin is currently trying to find the webdriver-manager and protractor executables in PATH - which is not always the case. 

Since the plugin knows the path to the executables' dir already (PROTRACTOR_DIR) it can simply execute them using their full paths.
