### PR TITLE
Fix #7 by breaking reference to user-supplied protractor options

### DIFF
--- a/gulp-angular-protractor/gulp-stream.js
+++ b/gulp-angular-protractor/gulp-stream.js
@@ -30,7 +30,7 @@ var
 
 module.exports = function (options, webDriverUrl) {
     var files = [],
-        args = options.args || [ ];
+        args = JSON.parse(JSON.stringify(options.args)) || [];
 
     return es.through(
         function(file) {


### PR DESCRIPTION
Breaks the reference to user-supplied protractor options by cloning the options object before it is used in the gulp-stream function.  The second call to gulp-stream will no longer have the args generated in the first run supplied as options.arg in the subsequent runs.
