### PR TITLE
Optional webdriver update

### DIFF
--- a/gulp-angular-protractor/gulp-stream.js
+++ b/gulp-angular-protractor/gulp-stream.js
@@ -45,8 +45,7 @@ module.exports = function (options, webDriverUrl, autoStartServer, webDriver) {
             // Start the Web Driver server
             try {
                 if (autoStartServer) {
-                    // Start the update, run the server, run protractor and stop the server
-                    webDriver.webDriverUpdateAndStart(() => {
+                      let callback = () => {
                         gutil.log(PLUGIN_NAME + ' - We will run the Protractor engine');
 
                         webDriver
@@ -67,8 +66,13 @@ module.exports = function (options, webDriverUrl, autoStartServer, webDriver) {
                                     }
                                 }
                             });
-                    }, verbose, options.webDriverUpdate, options.webDriverStart);
-
+                    };
+                    // Start the update, run the server, run protractor and stop the server
+                    if (options.skipWebDriverUpdate) {
+                      webDriver.webDriverStandaloneStart(callback, verbose, options.webDriverStart);
+                    } else {
+                      webDriver.webDriverUpdateAndStart(callback, verbose, options.webDriverUpdate, options.webDriverStart);
+                    }
                 } else {
                     // Just run protractor
                     webDriver.runProtractorAndWait(args, (code) => {

--- a/gulp-angular-protractor/gulp-stream.js
+++ b/gulp-angular-protractor/gulp-stream.js
@@ -67,8 +67,8 @@ module.exports = function (options, webDriverUrl, autoStartServer, webDriver) {
                                 }
                             });
                     };
-                    // Start the update, run the server, run protractor and stop the server
-                    if (options.skipWebDriverUpdate) {
+                    // Start the update (maybe), run the server, run protractor and stop the server
+                    if (options.webDriverUpdate && options.webDriverUpdate.skip) {
                       webDriver.webDriverStandaloneStart(callback, verbose, options.webDriverStart);
                     } else {
                       webDriver.webDriverUpdateAndStart(callback, verbose, options.webDriverUpdate, options.webDriverStart);

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,10 @@ If you want to use another protractor version instead the default one
 Type: `Object`
 Default: `undefined`
 
+### options.webDriverUpdate.skip
+Type: `Boolean`
+Default: `false`
+
 ### options.webDriverUpdate.browsers
 Type: `Array`
 Default: `['chrome']`


### PR DESCRIPTION
This would allow users to optionally update webdriver. On my machine this would allow me to gain ~10 seconds of waiting for checking if there's updates before the tests can start. 